### PR TITLE
Update Platformio.ini to allow ArduinoJson to use hash of commit

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ extra_scripts =
 	pre:pre_build.py
 	merge_firmware.py
 lib_deps = 
-	https://github.com/bblanchon/ArduinoJson.git @ 7.0.4
+	https://github.com/bblanchon/ArduinoJson.git#36e1eec
 	https://github.com/knolleary/pubsubclient.git
 	luc-github/ESP32SSDP@^1.2.1
 


### PR DESCRIPTION
It looks like the platform.ini now needs to have the commit hash rather than the version. @7.0.4 = Commit #36e1eec

PackageException: Package version 7.3.1+sha.e03d8ae doesn't satisfy requirements 7.0.4 based on PackageMetadata <type=library name=ArduinoJson version=7.3.1+sha.e03d8ae spec={'owner': None, 'id': None, 'name': 'ArduinoJson', 'requirements': '7.0.4', 'uri': 'git+https://github.com/bblanchon/ArduinoJson.git'}