### PR TITLE
Use Chamber Temp on X1 Series

### DIFF
--- a/src/blflow/fans.h
+++ b/src/blflow/fans.h
@@ -6,6 +6,7 @@
 const int FanPower1 = 17;
 const int FanPower2 = 16;
 
+
 int fanSpeed = 0; 
 
 void fansetup(){
@@ -14,8 +15,15 @@ void fansetup(){
 }
 
 void fanloop(){
-
-    float temperature = printerVariables.nozzletemp;
+    float temperature = 0;
+    // IF enabled then user the chamber temperature
+    if (printerConfig.chamberTempSwitch) {
+        temperature = printerVariables.chambertemp;
+    }
+    // otherwise use the nozzle temperature
+   else {
+    temperature = printerVariables.nozzletemp;
+    }
 
     fanSpeed = 0;
     for (size_t i = 1; i < printerConfig.fanGraph.size(); i++) {
@@ -36,6 +44,7 @@ void fanloop(){
         fanSpeed = printerConfig.staticFanSpeed;
     }
 
+    
     int rpm = map(fanSpeed, 0, 100, 0, 255);
 
     globalVariables.fanSpeed = fanSpeed;

--- a/src/blflow/filesystem.h
+++ b/src/blflow/filesystem.h
@@ -22,6 +22,7 @@ void saveFileSystem(){
     
     json["bssi"] = printerConfig.BSSID;
     // Debugging
+    json["chambertempswitch"] = printerConfig.chamberTempSwitch;
     json["debuging"] = printerConfig.debuging;
     json["debugingchange"] = printerConfig.debugingchange;
     json["mqttdebug"] = printerConfig.mqttdebug;
@@ -81,6 +82,8 @@ void loadFileSystem(){
         strcpy(printerConfig.accessCode, json["accessCode"]);
         strcpy(printerConfig.serialNumber, json["serialNumber"]);
         strcpy(printerConfig.BSSID, json["bssi"]);
+        
+        printerConfig.chamberTempSwitch, json["chambertempswitch"];
 
         // Debugging
         printerConfig.debuging = json["debuging"];

--- a/src/blflow/filesystem.h
+++ b/src/blflow/filesystem.h
@@ -83,7 +83,7 @@ void loadFileSystem(){
         strcpy(printerConfig.serialNumber, json["serialNumber"]);
         strcpy(printerConfig.BSSID, json["bssi"]);
         
-        printerConfig.chamberTempSwitch, json["chambertempswitch"];
+        printerConfig.chamberTempSwitch = json["chambertempswitch"];
 
         // Debugging
         printerConfig.debuging = json["debuging"];

--- a/src/blflow/mqttmanager.h
+++ b/src/blflow/mqttmanager.h
@@ -123,6 +123,7 @@ void ParseCallback(char *topic, byte *payload, unsigned int length){
     // filter["system"]["led_mode"] =  true;
     filter["print"]["fan_gear"] = true;
     filter["print"]["nozzle_temper"] = true;
+    filter["print"]["chamber_temper"] = true; //get the chamber temperatrue
 
     auto deserializeError = deserializeJson(messageobject, payload, length, DeserializationOption::Filter(filter));
     if (!deserializeError){
@@ -162,6 +163,13 @@ void ParseCallback(char *topic, byte *payload, unsigned int length){
         if (messageobject["print"].containsKey("nozzle_temper"))
         {
             printerVariables.nozzletemp = messageobject["print"]["nozzle_temper"].as<double>();
+            Changed = true;
+        }
+
+        // If this is an X1 printer then add the chamber temperature
+        if (messageobject["print"].containsKey("chamber_temper"))
+        {
+            printerVariables.chambertemp = messageobject["print"]["chamber_temper"].as<double>();
             Changed = true;
         }
 

--- a/src/blflow/types.h
+++ b/src/blflow/types.h
@@ -7,9 +7,10 @@ extern "C"
 #endif
 
     typedef struct PrinterVaraiblesStruct{
-        int chamberfan = 0;
-        double nozzletemp = 0;
+        int chamberfan = 0; // Chamber fan speed
+        double nozzletemp = 0; // Nozzle temperature 
         bool online = false;
+        double chambertemp = 0; // Chamber temperature
         String errorcode = "";
         //Time since
         unsigned long disconnectMQTTms = 0;        
@@ -40,6 +41,8 @@ extern "C"
         bool debugingchange = true;     //Default debugging level - to shows onChange
         bool mqttdebug = false;         //Writes each packet from BBLP to the serial log
 
+        bool chamberTempSwitch = false; //Switch from nozzle temp to chamber temp (X1 only)
+        
         bool staticFan = false;  
         int staticFanSpeed = 0;
 

--- a/src/blflow/web-server.h
+++ b/src/blflow/web-server.h
@@ -66,6 +66,8 @@ void handleGetOptions(){
     doc["code"] = obfuscate(printerConfig.accessCode);
     doc["id"] = obfuscate(printerConfig.serialNumber);
 
+    doc["chambertempswitch"] = printerConfig.chamberTempSwitch;
+    
     doc["staticfans"] = printerConfig.staticFan;
     doc["staticfanspeed"] = printerConfig.staticFanSpeed;
 
@@ -105,6 +107,7 @@ void submitOptions(){
             strcpy(printerConfig.serialNumber,temperserial);
         };
 
+        printerConfig.chamberTempSwitch = (webServer.arg("chambertempswitch") == "on");
         printerConfig.staticFan = (webServer.arg("staticfan") == "on");
         printerConfig.staticFanSpeed = webServer.arg("staticfanspeed").toInt();
 
@@ -203,8 +206,9 @@ void setupWebserver(){
 
     webServer.on("/sensorData", HTTP_GET, []() { //Send Current Sensor Info
         String jsonResponse = "{";
-        jsonResponse += "\"temp\":" + String(printerVariables.nozzletemp, 2) + ",";  // 2 decimal places
-        jsonResponse += "\"speed\":" + String(globalVariables.fanSpeed);
+        jsonResponse += "\"temp\":" + String(printerVariables.nozzletemp, 2) + ",";  // nozzle temp to 2 decimal places
+        jsonResponse += "\"chambertemp\":" + String(printerVariables.chambertemp, 2) + ",";  // chamber temp to 2 decimal places
+        jsonResponse += "\"speed\":" + String(globalVariables.fanSpeed); // fan speed 
         jsonResponse += "}";
 
         webServer.send(200, "application/json", jsonResponse);

--- a/src/www/fanpage.html
+++ b/src/www/fanpage.html
@@ -356,6 +356,7 @@
         </div>
         <div class="section">
           <div>Nozzle Temperature: <span id="tempValue">-</span> °C</div>
+          <div>Chamber Temperature: <span id="chambertempValue">-</span> °C</div>
           <div>Fan Speed: <span id="speedValue">-</span> %</div>
         </div>
       </div><!-- .form-container -->
@@ -373,6 +374,14 @@
           <input type='text' id='printercode' name='code' title='Enter the access code of your Bambulab Printer' value=''>
           <label>Printer Serial Number:</label>
           <input type='text' id='printerserial' name='serial' title='Enter the serial Number for your Bambulab Printer' value=''>
+          
+          <div class="switch-with-label">
+            <label class="switch">
+              <input type="checkbox" id="chambertempswitch" name='chambertempswitch'>
+              <span class="slider round"></span>
+            </label>
+            <span class="toggle-label">Use Chamber Temp</span>
+          </div>
 
           <h2>Features</h2>
           <div class="switch-with-label">
@@ -453,6 +462,7 @@
               document.getElementById('printerip').value = configData.ip || '';
               document.getElementById('printercode').value = configData.code || '';
               document.getElementById('printerserial').value = configData.id || '';
+              document.getElementById('chambertempswitch').checked = configData.chambertempswitch || false;
 
               document.getElementById('staticfan').checked = configData.staticfans || false;
               document.getElementById('staticfanspeed').value = configData.staticfanspeed || 0;
@@ -555,6 +565,7 @@
       .then(json => {
         document.getElementById('tempValue').textContent = json.temp;
         document.getElementById('speedValue').textContent = json.speed;
+        document.getElementById('chambertempValue').textContent = json.chambertemp;
         setSpin(json.speed);
       })
       .catch(err => console.error("Error fetching sensor data:", err));


### PR DESCRIPTION
This pull request allows the user to select to use the chamber temperature on the X1 series printers to set fan speeds.

It is fully functional and I have tested it, but it needs some tidy up around the interface to create temperature set points, My HTML and JavaScript is not the best, so I was hoping that you can pick it up and polish it.

The main point to fix is the temperature graph doesn't need to exceed 80 degrees.